### PR TITLE
Use the term “application” rather than “service”

### DIFF
--- a/infinitory/cellformatter.py
+++ b/infinitory/cellformatter.py
@@ -96,46 +96,47 @@ class Roles(Set):
         return Markup('<li><a href="../roles/index.html#%s">%s</a></li>') % (role, role)
 
 
-class Services(Set):
+class Applications(Set):
     def value(self, record):
         profile_metadata = record["facts"].get("profile_metadata", dict())
-        return sorted(profile_metadata.get("services", list()), key=itemgetter("human_name"))
+        applications = profile_metadata.get("services", list())
+        return sorted(applications, key=itemgetter("human_name"))
 
-    def item_html(self, service):
-        return Markup('<li><a href="../services/%s.html">%s</a></li>') % (
-            service["class_name"],
-            service["human_name"])
+    def item_html(self, application):
+        return Markup('<li><a href="../applications/%s.html">%s</a></li>') % (
+            application["class_name"],
+            application["human_name"])
 
-    def item_csv(self, service):
-        return service["class_name"]
+    def item_csv(self, application):
+        return application["class_name"]
 
 
-class Owners(Services):
-    def item_html(self, service):
-        if service.get("owner_uid", ":undef") == ":undef":
+class Owners(Applications):
+    def item_html(self, application):
+        if application.get("owner_uid", ":undef") == ":undef":
             return ""
         else:
-            return Markup('<li>%s</li>') % service["owner_uid"]
+            return Markup('<li>%s</li>') % application["owner_uid"]
 
-    def item_csv(self, service):
-        if service.get("owner_uid", ":undef") == ":undef":
+    def item_csv(self, application):
+        if application.get("owner_uid", ":undef") == ":undef":
             return ""
         else:
-            return service["owner_uid"]
+            return application["owner_uid"]
 
 
-class Teams(Services):
-    def item_html(self, service):
-        if service.get("team", ":undef") == ":undef":
+class Teams(Applications):
+    def item_html(self, application):
+        if application.get("team", ":undef") == ":undef":
             return ""
         else:
-            return Markup('<li>%s</li>') % service["team"]
+            return Markup('<li>%s</li>') % application["team"]
 
-    def item_csv(self, service):
-        if service.get("team", ":undef") == ":undef":
+    def item_csv(self, application):
+        if application.get("team", ":undef") == ":undef":
             return ""
         else:
-            return service["team"]
+            return application["team"]
 
 
 class Fqdn(Base):

--- a/infinitory/cli.py
+++ b/infinitory/cli.py
@@ -46,7 +46,7 @@ def output_html(inventory, directory):
     report_columns = [
         cellformatter.Fqdn("facts", "fqdn"),
         cellformatter.Teams("other", "teams"),
-        cellformatter.Services("other", "services"),
+        cellformatter.Applications("other", "applications"),
         cellformatter.Boolean("other", "monitoring"),
         cellformatter.Boolean("other", "backups"),
         cellformatter.Boolean("other", "logging"),
@@ -66,7 +66,7 @@ def output_html(inventory, directory):
         cellformatter.Base("facts", "fqdn"),
         cellformatter.Teams("other", "teams"),
         cellformatter.Owners("other", "owners"),
-        cellformatter.Services("other", "services"),
+        cellformatter.Applications("other", "applications"),
         cellformatter.Base("other", "icinga_notification_period", "Icinga notification period"),
         cellformatter.Base("other", "icinga_stage", header="Icinga stage"),
         cellformatter.Base("other", "icinga_owner", header="Icinga owner"),
@@ -111,24 +111,24 @@ def output_html(inventory, directory):
                 generation_time=generation_time,
                 roles=inventory.sorted_roles()))
 
-    os.mkdir("{}/services".format(directory), 0o755)
-    sorted_services = inventory.sorted_services()
+    os.mkdir("{}/applications".format(directory), 0o755)
+    sorted_applications = inventory.sorted_applications()
 
-    with open("{}/services/index.html".format(directory), "w", encoding="utf-8") as html:
+    with open("{}/applications/index.html".format(directory), "w", encoding="utf-8") as html:
         html.write(
-            render_template("services.html",
+            render_template("applications.html",
                 path="../",
                 generation_time=generation_time,
-                services=sorted_services))
+                applications=sorted_applications))
 
-    for service in sorted_services:
-        path = "{}/services/{}.html".format(directory, service["class_name"])
+    for application in sorted_applications:
+        path = "{}/applications/{}.html".format(directory, application["class_name"])
         with open(path, "w", encoding="utf-8") as html:
             html.write(
-                render_template("service.html",
+                render_template("application.html",
                     path="../",
                     generation_time=generation_time,
-                    service=service))
+                    application=application))
 
 def render_template(template_name, **kwargs):
     data_path = os.path.dirname(os.path.abspath(__file__))

--- a/infinitory/inventory.py
+++ b/infinitory/inventory.py
@@ -77,19 +77,23 @@ class Inventory(object):
     def sorted_roles(self):
         return sorted(self.roles.items())
 
-    def sorted_services(self):
-        services = dict()
+    def sorted_applications(self):
+        applications = dict()
 
         for node in self.nodes.values():
             profile_metadata = node["facts"].get("profile_metadata", dict())
+
+            # Previously we used the term “services” instead of “applications.”
+            # This was changed to avoid confusion since there is a related
+            # Puppet resource type called “Service.”
             service_facts = profile_metadata.get("services", list())
 
             for service_fact in service_facts:
                 class_name = service_fact["class_name"]
-                if class_name not in services:
-                    services[class_name] = service_fact
-                    services[class_name]["nodes"] = list()
+                if class_name not in applications:
+                    applications[class_name] = service_fact
+                    applications[class_name]["nodes"] = list()
 
-                services[class_name]["nodes"].append(node)
+                applications[class_name]["nodes"].append(node)
 
-        return sorted(services.values(), key=itemgetter("human_name"))
+        return sorted(applications.values(), key=itemgetter("human_name"))

--- a/infinitory/static/general.css
+++ b/infinitory/static/general.css
@@ -176,6 +176,6 @@ td p {
 }
 
 body#node th,
-body#service th {
+body#application th {
   width: 180px;
 }

--- a/infinitory/templates/application.html
+++ b/infinitory/templates/application.html
@@ -1,18 +1,18 @@
 {% extends "layout.html" %}
-{% block title %}Service {{ service["human_name"] }}{% endblock %}
+{% block title %}{{ application["human_name"] }}{% endblock %}
 {% block body %}
-  <h1>Service {{ service["human_name"] }}</h1>
+  <h1>{{ application["human_name"] }}</h1>
   <table>
     <tbody>
       <tr>
         <th>Class</th>
-        <td>{{ service["class_name"] }}</td>
+        <td>{{ application["class_name"] }}</td>
       </tr>
       <tr>
         <th>Documentation</th>
         <td>
           <ul>
-          {% for url in service["doc_urls"] %}
+          {% for url in application["doc_urls"] %}
             <li><a href="{{ url }}">{{url}}</a></li>
           {% endfor %}
           </ul>
@@ -20,14 +20,14 @@
       </tr>
       <tr>
         <th>Downtime impact</th>
-        <td>{{ service["downtime_impact"] | unundef }}</td>
+        <td>{{ application["downtime_impact"] | unundef }}</td>
       </tr>
       <tr>
         <th>End users</th>
         <td>
-        {% if service["end_users"] != ":undef" %}
+        {% if application["end_users"] != ":undef" %}
           <ul>
-          {% for email in service["end_users"] %}
+          {% for email in application["end_users"] %}
             <li><a href="mailto:{{ email }}">{{email}}</a></li>
           {% endfor %}
           </ul>
@@ -36,14 +36,14 @@
       </tr>
       <tr>
         <th>Escalation period</th>
-        <td>{{ service["escalation_period"] | unundef }}</td>
+        <td>{{ application["escalation_period"] | unundef }}</td>
       </tr>
       <tr>
         <th>Notes</th>
         <td>
           <div class="notes">
-          {% if service["notes"] %}
-            {{ service["notes"] | unundef | markdown }}
+          {% if application["notes"] %}
+            {{ application["notes"] | unundef | markdown }}
           {% endif %}
           </div>
         </td>
@@ -52,7 +52,7 @@
         <th>Other FQDNs</th>
         <td>
           <ul>
-          {% for fqdn in service["other_fqdns"] %}
+          {% for fqdn in application["other_fqdns"] %}
             <li>{{ fqdn }}</li>
           {% endfor %}
           </ul>
@@ -60,17 +60,17 @@
       </tr>
       <tr>
         <th>Owner</th>
-        <td>{{ service["owner_uid"] | unundef }}</td>
+        <td>{{ application["owner_uid"] | unundef }}</td>
       </tr>
       <tr>
         <th>Team</th>
-        <td>{{ service["team"] | unundef }}</td>
+        <td>{{ application["team"] | unundef }}</td>
       </tr>
       <tr>
         <th>Nodes</th>
         <td>
           <ul>
-          {% for node in service["nodes"] | sort(attribute='facts.fqdn') %}
+          {% for node in application["nodes"] | sort(attribute='facts.fqdn') %}
             <li><a href="../nodes/{{ node["certname"] }}.html">{{ node["facts"]["fqdn"] }}</a></li>
           {% endfor %}
           </ul>

--- a/infinitory/templates/applications.html
+++ b/infinitory/templates/applications.html
@@ -1,23 +1,23 @@
 {% extends "layout.html" %}
-{% block title %}Service inventory{% endblock %}
+{% block title %}Application inventory{% endblock %}
 {% block body %}
-  <h1>Service inventory</h1>
+  <h1>Application inventory</h1>
   <table>
     <thead>
       <tr>
-        <th>Service</th>
+        <th>Application</th>
         <th>Nodes</th>
       </tr>
     </thead>
     <tbody>
-    {% for service in services %}
-      <tr id="{{ service }}">
+    {% for application in applications %}
+      <tr id="{{ application }}">
         <th>
-          <a href="./{{ service["class_name"] }}.html">{{ service["human_name"] }}</a>
+          <a href="./{{ application["class_name"] }}.html">{{ application["human_name"] }}</a>
         </th>
         <td>
           <ul>
-          {% for node in service["nodes"] | sort(attribute="facts.fqdn") %}
+          {% for node in application["nodes"] | sort(attribute="facts.fqdn") %}
             <li><a href="../nodes/{{ node["certname"] }}.html">{{ node["facts"]["fqdn"] }}</a></li>
           {% endfor %}
           </ul>

--- a/infinitory/templates/home.html
+++ b/infinitory/templates/home.html
@@ -5,6 +5,6 @@
   <ul>
     <li><a href="nodes/index.html">Node inventory</a></li>
     <li><a href="roles/index.html">Role inventory</a></li>
-    <li><a href="services/index.html">Service inventory</a></li>
+    <li><a href="applications/index.html">Application inventory</a></li>
   </ul>
 {% endblock %}

--- a/infinitory/templates/layout.html
+++ b/infinitory/templates/layout.html
@@ -15,7 +15,7 @@
         <li class="infinitory-logo">∞</li>
         <li><a href="{{ path }}nodes/index.html">Nodes</a></li>
         <li><a href="{{ path }}roles/index.html">Roles</a></li>
-        <li><a href="{{ path }}services/index.html">Services</a></li>
+        <li><a href="{{ path }}applications/index.html">Applications</a></li>
       </ul>
     </nav>
     <main>


### PR DESCRIPTION
The term “service” is confusing because of the related Puppet resource type. “Application” makes it clear that this doesn't track running processes.

This will break some URLs, but I don't think anything references them right now. Redirects are a pain since this is just static HTML.